### PR TITLE
Add parameter for custom api to use domain part of email

### DIFF
--- a/gravatar_addressbook_backend.php
+++ b/gravatar_addressbook_backend.php
@@ -53,8 +53,10 @@ class gravatar_addressbook_backend extends rcube_addressbook
     }
 
     private static function _get_api_url($email, $api, &$vars){
+        $emailExploded = explode("@",$email);
+        $d = strtolower(trim($emailExploded[1]));
         $e = strtolower(trim($email));
-        $o = array('%e' => urlencode($e), '%m' => md5($e), '%a' => sha1($e));
+        $o = array('%e' => urlencode($e), '%m' => md5($e), '%a' => sha1($e),'%d' => urlencode($d));
         return strtr($api, array_merge($vars, $o));
     }
 

--- a/gravatar_addressbook_backend.php
+++ b/gravatar_addressbook_backend.php
@@ -53,10 +53,10 @@ class gravatar_addressbook_backend extends rcube_addressbook
     }
 
     private static function _get_api_url($email, $api, &$vars){
-        $emailExploded = explode("@",$email);
+        $emailExploded = explode("@", $email);
         $d = strtolower(trim($emailExploded[1]));
         $e = strtolower(trim($email));
-        $o = array('%e' => urlencode($e), '%m' => md5($e), '%a' => sha1($e),'%d' => urlencode($d));
+        $o = array('%e' => urlencode($e), '%m' => md5($e), '%a' => sha1($e), '%d' => urlencode($d));
         return strtr($api, array_merge($vars, $o));
     }
 


### PR DESCRIPTION
This adds possibility of adding new %d parameter to gravatar_custom_photo_api
which can be used to display nice images based on domain part of email with using clearbit web service (or any other simillar service)
for example: $config['gravatar_custom_photo_api'] = 'https://logo.clearbit.com/%d';